### PR TITLE
Fix: Correct sitemap URL in robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -2,4 +2,4 @@
 layout: none
 ---
 User-agent: *
-Sitemap: {{ site.url }}/sitemap.xml
+Sitemap: {{ site.url }}{{ site.baseurl }}/sitemap.xml


### PR DESCRIPTION
The sitemap URL was missing the `baseurl`, causing it to point to the wrong location. This change adds the `site.baseurl` to the URL in `robots.txt` to generate the correct sitemap link.